### PR TITLE
Added option for precision with minimum score value and option for adding "score" as new key/value pair to item.

### DIFF
--- a/src/FuzzySearch.js
+++ b/src/FuzzySearch.js
@@ -12,6 +12,7 @@ export default class FuzzySearch {
     this.options = Object.assign({
       caseSensitive: false,
       sort: false,
+      addScoreToItem: false
     }, options);
   }
 
@@ -43,6 +44,9 @@ export default class FuzzySearch {
             if (score) {
               found = true;
 
+              if(this.options.addScoreToItem){
+                item.score = score;
+              }
               results.push({ item, score });
 
               break;

--- a/src/FuzzySearch.js
+++ b/src/FuzzySearch.js
@@ -12,7 +12,8 @@ export default class FuzzySearch {
     this.options = Object.assign({
       caseSensitive: false,
       sort: false,
-      addScoreToItem: false
+      addScoreToItem: false,
+      maximumScore: 100
     }, options);
   }
 
@@ -47,7 +48,9 @@ export default class FuzzySearch {
               if(this.options.addScoreToItem){
                 item.score = score;
               }
-              results.push({ item, score });
+              if(score < this.options.maximumScore){
+                results.push({ item, score });
+              }
 
               break;
             }


### PR DESCRIPTION
Default precision for minimum score is 100.
Default for adding score as new key/value pair to item is false.

Code should work as it did before this PR if these two options are not used.